### PR TITLE
fix: explicitly adding return type for `vue` bidning function `useAniStates`

### DIFF
--- a/packages/vue/src/ani/use_ani_states.ts
+++ b/packages/vue/src/ani/use_ani_states.ts
@@ -5,11 +5,19 @@ import {
     type StateController,
     type StateProps,
 } from '@freestylejs/ani-core'
-import { onMounted, onUnmounted, readonly, ref } from 'vue'
+import { onMounted, onUnmounted, type Ref, readonly, ref } from 'vue'
 
-export function useAniStates<const AnimationStates extends AnimationStateShape>(
+export function useAniStates<
+    const AnimationStates extends Record<string, any> & AnimationStateShape,
+>(
     props: StateProps<AnimationStates>
-) {
+): readonly [
+    {
+        state: Readonly<Ref<keyof AnimationStates>>
+        timeline: Readonly<Ref<GetTimeline<AnimationStates>>>
+    },
+    StateController<AnimationStates>['transitionTo'],
+] {
     const statesController = createStates(props)
     const timeline = ref<GetTimeline<AnimationStates>>(
         statesController.timeline()
@@ -41,7 +49,12 @@ export function useAniStates<const AnimationStates extends AnimationStateShape>(
     }
 
     return [
-        { state: readonly(state), timeline: readonly(timeline) },
+        {
+            state: readonly(state) as Readonly<Ref<keyof AnimationStates>>,
+            timeline: readonly(timeline) as Readonly<
+                Ref<GetTimeline<AnimationStates>>
+            >,
+        },
         transitionTo,
     ] as const
 }


### PR DESCRIPTION
## 1. Description

Fix vue binding function useAniStates has type building error.

## 2. Changes

Add explicit return types.

## 3. Breaking change (y/n):

n

## 4. Additional Information(context, links, etc.)

## 5. Type of Change

-   [x] Bug Fix
-   [ ] Refactor
-   [ ] Enhancement
-   [ ] Documentation
-   [ ] Breaking API Changes
-   [ ] Other (please describe)

## 6. Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
